### PR TITLE
A way to avoid interpolating escaped $s (e.g `htl" \$NOinterp "`) to match Julia interpolation

### DIFF
--- a/src/macro.jl
+++ b/src/macro.jl
@@ -62,17 +62,13 @@ macro htl_str(expr::String)
     DOLLAR_NOESCAPE = r"(^\$)|([^\\](\\\\)*\$)"
     while true
         if match(DOLLAR_NOESCAPE,expr[start:strlen]) === nothing
-           #chunk = expr[start:strlen] # unused varible can be removed
-	   #println("done: $(expr[start:strlen])")
            push!(args, expr[start:strlen])
            break
         end
         idx = last(findnext(DOLLAR_NOESCAPE, expr, start)) # last char of match is "$"
-	#println("found\$: $(expr[start:idx])")
         push!(args, expr[start:prevind(expr, idx)])
         start = nextind(expr, idx)
         if length(expr) >= start && expr[start] == '$'
-	       #println("push: $(start)")
             push!(args, "\$")
             start += 1
             continue


### PR DESCRIPTION
Julia does not interpolate escaped \$ in strings, so `@htl(" \$NOinterp ")` and  `htl" \$NOinterp "` have different behavior. 
Replacing findnext('$' with a regexp for the next $ that is not preceded by an odd number of \\, I think brings `htl" "` closer to the expected Julia string interpolation behavior.

## Existing behavior
Note the extra interpolations for the 3rd and 4th.
```julia
julia> using HypertextLiteral
julia> NOinterp = "YES_I'm interpolated! ";

julia> @htl("$(NOinterp) $NOinterp \$(NOinterp) \$NOinterp \\$(NOinterp) \\NOinterp")
YES_I&apos;m interpolated!  YES_I&apos;m interpolated!  $(NOinterp) $NOinterp \YES_I&apos;m interpolated!  \NOinterp

julia> htl"$(NOinterp) $NOinterp \$(NOinterp) \$NOinterp \\$(NOinterp) \\NOinterp"
YES_I&apos;m interpolated!  YES_I&apos;m interpolated!  \YES_I&apos;m interpolated!  \YES_I&apos;m interpolated!  \\YES_I&apos;m interpolated!  \\NOinterp
```
## New behavior
Note that the escaped dollar signs still show the raw \\$ -- this is the expected difference to the cooked string from @htl.
```julia
julia> htl"$(NOinterp) $NOinterp \$(NOinterp) \$NOinterp \\$(NOinterp) \NOinterp"
YES_I&apos;m interpolated!  YES_I&apos;m interpolated!  \$(NOinterp) \$NOinterp \\YES_I&apos;m interpolated!  \NOinterp
```